### PR TITLE
Add support for more highway types

### DIFF
--- a/examples/high_zoom_map_style.js
+++ b/examples/high_zoom_map_style.js
@@ -33,8 +33,11 @@ var mapStyle = {
       "service",
       "track",
       "road",
+      "busway",
       "bus_stop",
       "taxi_stop",
+      "raceway",
+      "escape",
     ];
   },
 
@@ -162,7 +165,7 @@ var mapStyle = {
       return "#555555";
     }
     if (
-      ["footway", "pedestrian", "path", "steps"].includes(
+      ["footway", "pedestrian", "path", "steps", " living_street"].includes(
         feature.properties["area:highway"]
       ) ||
       (feature.properties["highway"] == "pedestrian" &&

--- a/examples/high_zoom_map_style.js
+++ b/examples/high_zoom_map_style.js
@@ -33,7 +33,6 @@ var mapStyle = {
       "service",
       "track",
       "road",
-      "bus",
       "bus_stop",
       "taxi_stop",
     ];

--- a/examples/high_zoom_map_style.js
+++ b/examples/high_zoom_map_style.js
@@ -33,6 +33,9 @@ var mapStyle = {
       "service",
       "track",
       "road",
+      "bus",
+      "bus_stop",
+      "taxi_stop",
     ];
   },
 


### PR DESCRIPTION
Added support for `area:highway=bus;bus_stop;taxi_stop` as per https://wiki.openstreetmap.org/wiki/Proposed_features/Street_area#Tagging